### PR TITLE
wait for postgres before launching service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,11 @@ FROM python:3.7-slim
 # to the terminal with out buffering it first
 #ENV PYTHONUNBUFFERED 1
 
+# install psql client
+RUN apt-get update && \
+    apt-get install -y postgresql-client && \
+    rm -rf /var/lib/apt/lists/
+
 # create root directory for our project in the container
 RUN mkdir /TA
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,6 +5,15 @@
 #touch ./logs/sse-access.log
 #tail -n 0 -f ./logs/sse*.log &
 
+set -e
+
+until PGPASSWORD="$DB_PASSWORD" psql -U "$DB_USER" -h "$DB_HOST" -c '\q' "$DB_NAME"; do
+  >&2 echo "Postgres is unavailable - sleeping"
+  sleep 5
+done
+
+>&2 echo "Postgres is up - starting service"
+
 #export DJANGO_SETTINGS_MODULE=sse.settings
 # Apply database migrations
 echo "Apply database migrations"


### PR DESCRIPTION
I am currently working on integrating this service with [the docker-compose set up for our demonstrator](https://github.com/somnonetz/snet-xnat-docker-compose/) and have run into the following problem:

a race condition can occur if the service is deployed in an automated fashion (ie using something like docker-compose rather than by issuing the docker commands manually). If the django application container boots before the postgres db is ready, it will crash with the following output:

```
ta_1     | django.db.utils.OperationalError: could not connect to server: Connection refused
ta_1     | 	Is the server running on host "ta-db" (172.18.0.2) and accepting
ta_1     | 	TCP/IP connections on port 5432?
```

To fix this, this PR modifies the entrypoint to wait for postgres to start before launching the web server.

This requires the psql client, so installation of this has been added to the Dockerfile