### PR TITLE
increase keyId max_length to 255

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -4,7 +4,7 @@ from django.db import models
 class FileNo(models.Model):
     w = models.CharField(max_length=255)
     fileno = models.IntegerField()
-    keyId = models.CharField(max_length=20)
+    keyId = models.CharField(max_length=255)
     def __str__(self):
         return '%s %d' % (self.w, self.fileno)
     class Meta:
@@ -13,7 +13,7 @@ class FileNo(models.Model):
 class SearchNo(models.Model):
     w = models.CharField(max_length=255)
     searchno = models.IntegerField()
-    keyId = models.CharField(max_length=20)
+    keyId = models.CharField(max_length=255)
     def __str__(self):
         return '%s %d' % (self.w, self.searchno)
     class Meta:
@@ -21,7 +21,7 @@ class SearchNo(models.Model):
     
 class Key(models.Model):
     key = models.CharField(max_length=512)
-    keyId = models.CharField(max_length=20,unique=True)
+    keyId = models.CharField(max_length=255,unique=True)
     def __str__(self):
         return '%s %d' % (self.key,self.keyId)
 


### PR DESCRIPTION
Increase the maximum length of the keyID field inordeer to support more
key formats (specifically UUID keys)

The value 255 was chosen as according to the Django documentation this
is the maximum length for unique VARCHAR columns on MySQL:
https://docs.djangoproject.com/en/dev/ref/databases/#character-fields